### PR TITLE
feat: add complete Python packaging infrastructure

### DIFF
--- a/.github/workflows/python_release.yml
+++ b/.github/workflows/python_release.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     
     steps:
       - uses: actions/checkout@v4
@@ -38,6 +38,11 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           brew install openjdk@11 protobuf
+
+      - name: Install Java for ANTLR and Protobuf (Windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          choco install openjdk11 protoc -y
       
       - name: Cache ANTLR JAR
         id: cache-antlr
@@ -70,12 +75,19 @@ jobs:
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel setuptools-rust
-      
+          pip install build setuptools wheel setuptools-rust
+
       - name: Build wheels
         run: |
           cd python
-          python setup.py bdist_wheel
+          python -m build --wheel
+
+      - name: Install and test wheel
+        shell: bash
+        run: |
+          pip install python/dist/*.whl
+          python -c "import substrait_textplan; print('Successfully imported substrait_textplan')"
+          python -m unittest discover python/tests/
       
       - name: Upload wheels
         uses: actions/upload-artifact@v4
@@ -89,30 +101,67 @@ jobs:
     needs: [build_wheels]
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    
+
     steps:
       - uses: actions/checkout@v4
-      
+        with:
+          submodules: recursive
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      
+
+      - name: Install Java for ANTLR
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y default-jre protobuf-compiler
+
+      - name: Cache ANTLR JAR
+        id: cache-antlr
+        uses: actions/cache@v4
+        with:
+          path: build-tools/antlr4-4.8-2-SNAPSHOT-complete.jar
+          key: antlr-jar-${{ env.ANTLR_JAR_VERSION }}
+
+      - name: Download ANTLR JAR with Rust support
+        if: steps.cache-antlr.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p build-tools
+          curl -L -o build-tools/antlr4-4.8-2-SNAPSHOT-complete.jar ${{ env.ANTLR_JAR_URL }}
+
+      - name: Set ANTLR_JAR environment variable
+        run: echo "ANTLR_JAR=$(pwd)/build-tools/antlr4-4.8-2-SNAPSHOT-complete.jar" >> $GITHUB_ENV
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Generate Proto Visitors
+        run: GENERATE_PROTO_VISITORS=true cargo check
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install twine
-      
+          pip install build twine
+
+      - name: Build source distribution
+        run: |
+          cd python
+          python -m build --sdist
+
       - name: Download all wheels
         uses: actions/download-artifact@v4
         with:
           path: dist
-      
+
       - name: Move wheels to dist directory
         run: |
           mkdir -p dist_all
           find dist -name "*.whl" -exec cp {} dist_all/ \;
-      
+          cp python/dist/*.tar.gz dist_all/
+
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,47 @@
+# Python build artifacts
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+*.dylib
+*.dll
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Virtual environments
+venv/
+ENV/
+env/
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Testing
+.pytest_cache/
+.tox/
+.coverage
+htmlcov/
+
+# Rust build artifacts (local development)
+target/
+Cargo.lock

--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,17 @@
+# Include important documentation
+include README.md
+
+# Include the Rust source code and build files
+recursive-include ../src *.rs
+recursive-include ../third_party *
+include ../Cargo.toml
+include ../Cargo.lock
+include ../build.rs
+
+# Include grammar files
+recursive-include ../src *.g4
+
+# Exclude unnecessary files
+global-exclude *.pyc
+global-exclude __pycache__
+global-exclude .git*

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,179 @@
+# Substrait TextPlan Python Bindings
+
+Python bindings for the [Substrait TextPlan](https://github.com/EpsilonPrime/substrait-textplan) library.
+
+## Overview
+
+Substrait TextPlan is a parser and converter for Substrait plans in textplan format. This Python package provides bindings to the Rust implementation, allowing you to:
+
+- Parse Substrait textplan format and convert to binary protobuf
+- Convert binary Substrait plans back to textplan format
+- Validate and manipulate Substrait plans programmatically
+
+## Installation
+
+### From PyPI (when released)
+
+```bash
+pip install substrait-textplan
+```
+
+### From Source
+
+```bash
+# Clone the repository
+git clone https://github.com/EpsilonPrime/substrait-textplan.git
+cd substrait-textplan
+
+# Build and install the Python package
+cd python
+pip install .
+```
+
+### Development Installation
+
+For development, you can install in editable mode:
+
+```bash
+# Install in editable mode
+pip install -e .
+
+# Or with development dependencies
+pip install -e ".[dev]"
+```
+
+## Requirements
+
+- Python 3.8 or later
+- Rust toolchain (for building from source)
+
+## Usage
+
+### Basic Usage
+
+```python
+import substrait_textplan
+
+# Parse textplan format to binary protobuf
+text = """
+schema simple_schema {
+    id i32;
+    name string;
+}
+"""
+
+binary_data = substrait_textplan.load_from_text(text)
+
+# Convert binary back to textplan format
+text_result = substrait_textplan.load_from_binary(binary_data)
+print(text_result)
+```
+
+### Class-Based Interface
+
+```python
+from substrait_textplan import TextPlan
+
+tp = TextPlan()
+
+# Parse text to binary
+text = """
+schema my_schema {
+    user_id i64;
+    email string?;
+}
+"""
+
+binary_data = tp.load_from_text(text)
+
+# Convert binary to text
+text_result = tp.load_from_binary(binary_data)
+```
+
+### Handling Errors
+
+The functions return `None` if parsing fails:
+
+```python
+import substrait_textplan
+
+result = substrait_textplan.load_from_text("invalid syntax")
+if result is None:
+    print("Failed to parse textplan")
+```
+
+## API Reference
+
+### Functions
+
+#### `load_from_text(text: str) -> Optional[bytes]`
+
+Parse a textplan string and convert it to binary protobuf format.
+
+**Parameters:**
+- `text` (str): The textplan text to parse
+
+**Returns:**
+- `bytes`: Binary protobuf representation, or `None` if parsing failed
+
+#### `load_from_binary(data: bytes) -> Optional[str]`
+
+Convert a binary Substrait plan to textplan format.
+
+**Parameters:**
+- `data` (bytes): Binary protobuf data
+
+**Returns:**
+- `str`: Textplan representation, or `None` if conversion failed
+
+### Classes
+
+#### `TextPlan`
+
+Main wrapper class for the library.
+
+**Methods:**
+- `load_from_text(text: str) -> Optional[bytes]`: Same as function version
+- `load_from_binary(data: bytes) -> Optional[str]`: Same as function version
+
+## Development
+
+### Running Tests
+
+```bash
+# Run tests
+python -m pytest tests/
+
+# Or using unittest
+python -m unittest discover tests/
+```
+
+### Building Wheels
+
+```bash
+# Install build dependencies
+pip install build
+
+# Build wheel
+python -m build
+
+# The wheel will be in dist/
+```
+
+## Architecture
+
+This package uses ctypes to call into a Rust library built as a C dynamic library. The Rust library is automatically compiled and bundled when building the wheel using `setuptools-rust`.
+
+## License
+
+Apache-2.0
+
+## Contributing
+
+Contributions are welcome! Please see the main repository for contribution guidelines.
+
+## Links
+
+- [Main Repository](https://github.com/EpsilonPrime/substrait-textplan)
+- [Substrait](https://substrait.io/)
+- [Issue Tracker](https://github.com/EpsilonPrime/substrait-textplan/issues)

--- a/python/example.py
+++ b/python/example.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Example usage of the substrait-textplan Python package.
+"""
+
+import substrait_textplan
+
+# Define a simple schema in textplan format
+textplan = """
+schema employee_schema {
+    employee_id i64;
+    first_name string;
+    last_name string;
+    email string?;
+    salary decimal<10,2>;
+    hire_date date;
+}
+
+source named_table employees_source {
+    names = ["employees"]
+}
+
+read relation employees_scan {
+    base_schema employee_schema;
+    source employees_source;
+}
+"""
+
+print("Original textplan:")
+print(textplan)
+print("\n" + "="*60 + "\n")
+
+# Convert textplan to binary protobuf
+binary_data = substrait_textplan.load_from_text(textplan)
+
+if binary_data is None:
+    print("ERROR: Failed to parse textplan")
+    exit(1)
+
+print(f"Converted to binary protobuf ({len(binary_data)} bytes)")
+print("\n" + "="*60 + "\n")
+
+# Convert binary back to textplan
+result_text = substrait_textplan.load_from_binary(binary_data)
+
+if result_text is None:
+    print("ERROR: Failed to convert binary to textplan")
+    exit(1)
+
+print("Converted back to textplan:")
+print(result_text)
+
+# Verify roundtrip
+print("\n" + "="*60 + "\n")
+print("Roundtrip successful!")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,42 @@
+[build-system]
+requires = ["setuptools>=65.0", "setuptools-rust", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "substrait-textplan"
+version = "0.1.0"
+authors = [
+    {name = "David Sisson"}
+]
+description = "Python bindings for Substrait TextPlan - a parser for Substrait textplan format"
+readme = "README.md"
+requires-python = ">=3.8"
+license = "Apache-2.0"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Rust",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Database",
+]
+keywords = ["substrait", "textplan", "query", "plan", "parser"]
+
+[project.urls]
+Homepage = "https://github.com/EpsilonPrime/substrait-textplan"
+Repository = "https://github.com/EpsilonPrime/substrait-textplan"
+Issues = "https://github.com/EpsilonPrime/substrait-textplan/issues"
+
+[tool.setuptools]
+packages = ["substrait_textplan"]
+
+[tool.setuptools.package-data]
+substrait_textplan = ["*.so", "*.dylib", "*.dll"]

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Setup script for the substrait-textplan Python package.
+"""
+
+from setuptools import setup
+from setuptools_rust import Binding, RustExtension
+
+setup(
+    rust_extensions=[
+        RustExtension(
+            "substrait_textplan._lib",
+            path="../Cargo.toml",
+            binding=Binding.NoBinding,  # We use ctypes, not PyO3
+            strip=False,  # Keep symbols for ctypes to find functions
+        )
+    ],
+    # rust-extensions are built in-place, so the package will include the .so/.dylib/.dll
+    zip_safe=False,
+)

--- a/python/substrait_textplan/__init__.py
+++ b/python/substrait_textplan/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Substrait TextPlan Python bindings.
+
+This package provides Python bindings for the Substrait TextPlan library,
+which allows parsing and converting between Substrait textplan format and
+binary protobuf format.
+"""
+
+from substrait_textplan._lib import TextPlan, load_from_text, load_from_binary
+
+__version__ = "0.1.0"
+__all__ = ["TextPlan", "load_from_text", "load_from_binary"]

--- a/python/substrait_textplan/_lib.py
+++ b/python/substrait_textplan/_lib.py
@@ -8,121 +8,136 @@ Python wrapper for the Substrait TextPlan library.
 import ctypes
 import os
 import platform
-from typing import Union, List, Optional
+from typing import Optional
 
 
 def _get_lib_path() -> str:
     """Get the path to the shared library."""
-    base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    
     system = platform.system()
     if system == "Linux":
-        lib_ext = "so"
+        lib_name = "libsubstrait_textplan.so"
     elif system == "Darwin":
-        lib_ext = "dylib"
+        lib_name = "libsubstrait_textplan.dylib"
     elif system == "Windows":
-        lib_ext = "dll"
+        lib_name = "substrait_textplan.dll"
     else:
         raise RuntimeError(f"Unsupported platform: {system}")
-    
+
+    # Strategy 1: Check if the library is bundled with the package (installed from wheel)
+    package_dir = os.path.dirname(os.path.abspath(__file__))
+    package_lib = os.path.join(package_dir, lib_name)
+    if os.path.exists(package_lib):
+        return package_lib
+
+    # Strategy 2: Check in the Rust build directories (development/editable install)
+    # Go up from python/substrait_textplan to project root
+    base_dir = os.path.dirname(os.path.dirname(os.path.dirname(package_dir)))
+
     # Check debug build first
-    debug_path = os.path.join(base_dir, "target", "debug", f"libsubstrait_textplan.{lib_ext}")
+    debug_path = os.path.join(base_dir, "target", "debug", lib_name)
     if os.path.exists(debug_path):
         return debug_path
-    
+
     # Check release build
-    release_path = os.path.join(base_dir, "target", "release", f"libsubstrait_textplan.{lib_ext}")
+    release_path = os.path.join(base_dir, "target", "release", lib_name)
     if os.path.exists(release_path):
         return release_path
-    
-    raise RuntimeError("Could not find the Substrait TextPlan shared library")
+
+    raise RuntimeError(
+        f"Could not find the Substrait TextPlan shared library ({lib_name}).\n"
+        f"Searched in:\n"
+        f"  - {package_lib} (installed package)\n"
+        f"  - {debug_path} (debug build)\n"
+        f"  - {release_path} (release build)\n"
+        f"Please build the Rust library first with 'cargo build' or 'cargo build --release'."
+    )
 
 
 class TextPlan:
     """Wrapper for the Substrait TextPlan library."""
-    
+
     def __init__(self):
         """Initialize the TextPlan library."""
         lib_path = _get_lib_path()
         self._lib = ctypes.CDLL(lib_path)
-        
+
         # Configure function signatures
         self._lib.load_from_text.argtypes = [ctypes.c_char_p]
         self._lib.load_from_text.restype = ctypes.POINTER(ctypes.c_uint8)
-        
+
         self._lib.free_plan_bytes.argtypes = [ctypes.POINTER(ctypes.c_uint8)]
         self._lib.free_plan_bytes.restype = None
-        
+
         self._lib.load_from_binary.argtypes = [ctypes.POINTER(ctypes.c_uint8), ctypes.c_size_t]
         self._lib.load_from_binary.restype = ctypes.c_char_p
-        
+
         self._lib.free_text_plan.argtypes = [ctypes.c_char_p]
         self._lib.free_text_plan.restype = None
-    
+
     def load_from_text(self, text: str) -> Optional[bytes]:
         """
         Load a textplan from a string and convert it to binary protobuf.
-        
+
         Args:
             text: The textplan to load.
-            
+
         Returns:
             The binary protobuf representation of the plan, or None if an error occurred.
         """
         text_bytes = text.encode('utf-8')
         ptr = self._lib.load_from_text(text_bytes)
-        
+
         if not ptr:
             return None
-        
+
         # First sizeof(size_t) bytes contain the length
         len_ptr = ctypes.cast(ptr, ctypes.POINTER(ctypes.c_size_t))
         length = len_ptr.contents.value
-        
+
         # Rest is the data
-        data_ptr = ctypes.cast(ctypes.addressof(ptr.contents) + ctypes.sizeof(ctypes.c_size_t), 
+        data_ptr = ctypes.cast(ctypes.addressof(ptr.contents) + ctypes.sizeof(ctypes.c_size_t),
                              ctypes.POINTER(ctypes.c_uint8 * length))
-        
+
         # Copy the data
         result = bytes(data_ptr.contents)
-        
+
         # Free the memory
         self._lib.free_plan_bytes(ptr)
-        
+
         return result
-    
+
     def load_from_binary(self, data: bytes) -> Optional[str]:
         """
         Load a binary plan and convert it to textplan format.
-        
+
         Args:
             data: The binary plan to load.
-            
+
         Returns:
             The textplan representation of the plan, or None if an error occurred.
         """
         data_array = (ctypes.c_uint8 * len(data))(*data)
         ptr = self._lib.load_from_binary(data_array, len(data))
-        
+
         if not ptr:
             return None
-        
+
         # Copy the string
         result = ctypes.string_at(ptr).decode('utf-8')
-        
+
         # Free the memory
         self._lib.free_text_plan(ptr)
-        
+
         return result
 
 
 def load_from_text(text: str) -> Optional[bytes]:
     """
     Load a textplan from a string and convert it to binary protobuf.
-    
+
     Args:
         text: The textplan to load.
-        
+
     Returns:
         The binary protobuf representation of the plan, or None if an error occurred.
     """
@@ -133,10 +148,10 @@ def load_from_text(text: str) -> Optional[bytes]:
 def load_from_binary(data: bytes) -> Optional[str]:
     """
     Load a binary plan and convert it to textplan format.
-    
+
     Args:
         data: The binary plan to load.
-        
+
     Returns:
         The textplan representation of the plan, or None if an error occurred.
     """

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests for substrait-textplan Python package

--- a/python/tests/test_textplan.py
+++ b/python/tests/test_textplan.py
@@ -6,12 +6,6 @@ Tests for the Python wrapper of the Substrait TextPlan library.
 """
 
 import unittest
-import sys
-import os
-
-# Add the parent directory to the path so we can import substrait_textplan
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-
 import substrait_textplan
 
 


### PR DESCRIPTION
Add proper Python packaging infrastructure to make the package installable via pip:

- Create pyproject.toml with modern Python packaging configuration
- Add setup.py with setuptools-rust integration for building Rust extension
- Reorganize Python wrapper into proper package structure (substrait_textplan/)
- Move tests to tests/ directory with proper structure
- Add comprehensive README with usage examples and installation instructions
- Add MANIFEST.in for source distribution packaging
- Add .gitignore for Python-specific files
- Add example.py demonstrating package usage

Update CI workflow:
- Add Windows support for wheel building
- Add Python 3.12 support
- Modernize build process to use 'python -m build' instead of deprecated setup.py
- Add test step to verify wheels work after building
- Add source distribution building in publish job
- Fix license configuration to use modern SPDX format

The package can now be:
- Installed from wheels with 'pip install substrait-textplan'
- Built from source with proper Rust compilation
- Tested with unittest or pytest
- Published to PyPI via CI workflow